### PR TITLE
Add support for custom environment variables

### DIFF
--- a/templates/client-daemonset.yaml
+++ b/templates/client-daemonset.yaml
@@ -66,6 +66,12 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            {{- if .Values.client.extraEnvironmentVars }}
+            {{- range $key, $value := .Values.client.extraEnvironmentVars }}
+            - name: {{ $key }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- end }}
           command:
             - "/bin/sh"
             - "-ec"

--- a/test/unit/client-daemonset.bats
+++ b/test/unit/client-daemonset.bats
@@ -220,3 +220,32 @@ load _helpers
       yq -r '.spec.template.spec.containers[0].command | map(select(test("/consul/userconfig/foo"))) | length' | tee /dev/stderr)
   [ "${actual}" = "1" ]
 }
+
+#--------------------------------------------------------------------
+# extraEnvironmentVariables
+
+@test "client/DaemonSet: custom environment variables" {
+  cd `chart_dir`
+  local object=$(helm template \
+      -x templates/client-daemonset.yaml  \
+      --set 'client.extraEnvironmentVars.custom_proxy=fakeproxy' \
+      --set 'client.extraEnvironmentVars.no_proxy=custom_no_proxy' \
+      . | tee /dev/stderr |
+      yq -r '.spec.template.spec.containers[0].env' | tee /dev/stderr)
+
+  local actual=$(echo $object |
+      yq -r '.[3].name' | tee /dev/stderr)
+  [ "${actual}" = "custom_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[3].value' | tee /dev/stderr)
+  [ "${actual}" = "fakeproxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[4].name' | tee /dev/stderr)
+  [ "${actual}" = "no_proxy" ]
+
+  local actual=$(echo $object |
+      yq -r '.[4].value' | tee /dev/stderr)
+  [ "${actual}" = "custom_no_proxy" ]
+}

--- a/values.yaml
+++ b/values.yaml
@@ -137,6 +137,15 @@ client:
     #   name: my-secret
     #   load: false # if true, will add to `-config-dir` to load by Consul
 
+  # extraEnvVars is a list of extra enviroment variables to set with the pod. These could be
+  # used to include proxy settings required for cloud auto-join feature, 
+  # in case kubernetes cluster is behind egress http proxies. Additionally, it could be used to configure
+  # custom consul parameters.
+  extraEnvironmentVars: {}
+    # http_proxy: http://localhost:3128
+    # https_proxy: http://localhost:3128
+    # no_proxy: internal.domain.com
+
 # Configuration for DNS configuration within the Kubernetes cluster.
 # This creates a service that routes to all agents (client or server)
 # for serving DNS requests. This DOES NOT automatically configure kube-dns


### PR DESCRIPTION
To support [cloud auto join](https://www.consul.io/docs/agent/cloud-auto-join.html) capabilities in our infrastructure, we needed to add proxies in the client daemon set. This feature will also support custom consul parameters.